### PR TITLE
add note about using Ubuntu 20.04 for using the llvm.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is a basic starter repo designed for writing LLVM passes to help Holistic S
 
 ## Installing LLVM
 
+This requires **Ubuntu 20.04** (and will not work with 22.04).
+
 ```
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh


### PR DESCRIPTION
llvm ppa ([here](https://apt.llvm.org/jammy/dists/)) for Ubuntu 22.04 that the `llvm.sh` script add, does not contain llvm-12. This would only work till Ubuntu 20.04. This note informs the user to use Ubuntu 20.04 due to this limitation.